### PR TITLE
Specify lambda return type to keep clang happy

### DIFF
--- a/ebpf-bolt.cc
+++ b/ebpf-bolt.cc
@@ -193,7 +193,7 @@ void print_aggregated(unsigned long long base_addr, unsigned long long end_addr)
     if (addr >= base_addr && addr < end_addr)
       return addr - base_addr; // PIE, offset from base address
     else if (addr < base_addr)
-      return 0; // avoid conflicting addresses
+      return 0ULL; // avoid conflicting addresses
     return addr; // external address, don't care
   };
   fprintf(stderr, "%ld traces\n", traces.size());


### PR DESCRIPTION
Fixing this on Clang 19:

```
ebpf-bolt.cc:196:7: error: return type 'int' must match previous return type 'unsigned long long' when lambda expression has unspecified explicit return type
  196 |       return 0; // avoid conflicting addresses
      |       ^
```